### PR TITLE
[codex] Centralize CI tool versions in package.json

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,13 +21,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version-file: package.json
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -59,13 +57,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version-file: package.json
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "mdconvwk",
 	"type": "module",
+	"packageManager": "pnpm@9",
+	"engines": {
+		"node": "20"
+	},
 	"scripts": {
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy --minify",


### PR DESCRIPTION
## Summary

- Move pnpm version selection from GitHub Actions workflow inputs into `package.json` `packageManager` where applicable.
- Move single Node.js CI version selections into `package.json` `engines.node` and have `actions/setup-node` read `node-version-file: package.json`.
- Leave existing major versions and exact versions unchanged; this only centralizes the source of truth.

## Impact

CI keeps using the same pnpm and Node versions, but the versions now live with the project metadata. This makes local tooling and CI easier to compare.

## Validation

- `jq empty` on updated `package.json`
- `git diff --check`
- `actionlint .github/workflows/*.y*ml`
