### PR TITLE
Verify aqua registry update with pnpm fix

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
 registries:
   - type: standard
-    ref: v4.531.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.532.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: evilmartians/lefthook@v2.1.9
   - name: suzuki-shunsuke/pinact@v4.1.0


### PR DESCRIPTION
## Summary

- update the aqua standard registry from v4.531.0 to v4.532.0
- validate the registry update on the current main branch, which includes the pnpm setup fix

## Root cause being verified

The earlier dependency-update check failed in `pnpm/action-setup` while its self-installer attempted to switch pnpm versions, before repository install or test commands ran. The current main branch pins the bootstrap-compatible pnpm version, so this PR verifies the same registry update against that fix.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm typecheck`
- `CI=true pnpm run lint`
- `CI=true pnpm run fmt:check`
- `CI=true pnpm test:ci` (13 tests passed)
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`
- `git diff --check`
