### PR TITLE
Update pnpm to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mdconvwk",
 	"type": "module",
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"engines": {
 		"node": "24"
 	},


### PR DESCRIPTION
## What changed

- Update `package.json#packageManager` from `pnpm@11.11.0` to exact `pnpm@11.13.0`.
- Keep the workflow version-free so `package.json` remains the pnpm version source of truth.
- Leave `pnpm-lock.yaml` unchanged because resolving it with pnpm 11.13.0 produced no diff.

## Why

The pnpm 11.12.0 update fails in `pnpm/action-setup` v6.0.9 while its self-installer switches versions, before dependency installation starts:

`Cannot use 'in' operator to search for 'integrity' in undefined`

pnpm 11.13.0 contains the package publication fix needed by that self-update path.

## Validation

- `CI=true npx --yes pnpm@11.13.0 install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm test:ci` (13 tests passed)
- `pnpm run cf-typegen` (command succeeded; generated-file drift is outside this package-manager-only change)
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`

The PR remains draft until GitHub Actions confirms the `pnpm/action-setup` self-update path.
