### PR TITLE
Add missing-run recovery for GitHub Actions

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,6 +1,7 @@
 name: GitHub Actions Security
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,7 @@
 name: CI/CD
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
       - README.md
@@ -43,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     needs: test-lint-format
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mdconvwk",
 	"type": "module",
-	"packageManager": "pnpm@11.19.0",
+	"packageManager": "pnpm@11.20.0",
 	"engines": {
 		"node": "24"
 	},


### PR DESCRIPTION
## What changed

- add `workflow_dispatch` to CI/CD and GitHub Actions Security
- run the existing validation jobs for manual recovery without duplicating checks
- restrict deployment to `push` events on `main`, so manual recovery never deploys or uses deployment secrets
- update pnpm from 11.19.0 to 11.20.0 so the recovery path is verified with the affected dependency update

## Why

PR #191 has no GitHub Actions runs for its current head even though its workflow definitions and trigger eligibility match previously working revisions. A manual dispatch path provides a safe recovery mechanism when the automatic run is missing.

## Validation

- YAML syntax parse
- `pnpm install --frozen-lockfile` with pnpm 11.20.0
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm run test:ci` (13 tests)
- `pinact run --check`
- `zizmor --format github .`
